### PR TITLE
Add page `subtitle` into head <title>

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>Eleventy</title>
+		<title>{{ subtitle + ' - ' if subtitle}} Eleventy</title>
 {%- set css %}
 {% include 'index.css' %}
 {% include 'components/lists.css' %}


### PR DESCRIPTION
Adds the doc page's `subtitle` into the HTML head `<title>` element.

**Why?** I often navigate docs by simply typing a portion of a page's title into the browser's address bar, but currently all docs pages have the same title, `Eleventy`.

(New to nunjucks; there's probably a better way to handle the `subtitle` in `layouts/base.njk`.)

Before:
<img width="763" alt="before" src="https://user-images.githubusercontent.com/1187075/43993235-46748422-9d58-11e8-8b1c-5598c005fd58.png">

After:
<img width="768" alt="after" src="https://user-images.githubusercontent.com/1187075/43993237-4a082bb6-9d58-11e8-9865-24d6a6f2f468.png">
