### PR TITLE
Fix minor typo

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -18,7 +18,7 @@ title: My Rad Blog
 # My Rad Markdown Blog Post
 ```
 
-This will look for a `mylayout.njk` Nunjucks template file in your _includes_ folder (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
+This will look for a `mylayout.njk` Nunjucks template file in your _includes folder_ (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
 
 If you omit the file extension (`layout: mylayout`), eleventy will cycle through all of the supported template formats (`mylayout.*`) to look for a matching layout file.
 
@@ -68,7 +68,7 @@ All of this will output the following HTML content:
 
 {% addedin "0.2.7" %}
 
-Layouts can be a full path inside of the `_includes` folder, like so:
+Layouts can be a full path inside of the _includes folder_, like so:
 
 ```
 ---

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -18,7 +18,7 @@ title: My Rad Blog
 # My Rad Markdown Blog Post
 ```
 
-This will look for a `mylayout.njk` Nunjucks template file in your `_includes` folder (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
+This will look for a `mylayout.njk` Nunjucks template file in your `includes` folder (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
 
 If you omit the file extension (`layout: mylayout`), eleventy will cycle through all of the supported template formats (`mylayout.*`) to look for a matching layout file.
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -18,7 +18,7 @@ title: My Rad Blog
 # My Rad Markdown Blog Post
 ```
 
-This will look for a `mylayout.njk` Nunjucks template file in your `includes` folder (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
+This will look for a `mylayout.njk` Nunjucks template file in your _includes_ folder (`_includes/mylayout.njk`). You can use any template type in your layout—it doesn’t have to match the template type of the content. An `ejs` template can use a `njk` layout, for example.
 
 If you omit the file extension (`layout: mylayout`), eleventy will cycle through all of the supported template formats (`mylayout.*`) to look for a matching layout file.
 


### PR DESCRIPTION
The layouts page referenced to the `_includes`  while the object key is `dir.includes`