### PR TITLE
clarify that front matter does not support template syntax

### DIFF
--- a/docs/data-frontmatter.md
+++ b/docs/data-frontmatter.md
@@ -24,7 +24,7 @@ Locally assigned front matter values override things further up the layout chain
 
 Here are a few special front matter keys you can assign:
 
-* `permalink`: Add in front matter to change the output target of the current template. You can use template syntax for variables here. [Read more about Permalinks](/docs/permalinks/).
+* `permalink`: Add in front matter to change the output target of the current template. Normally, you cannot use template syntax for variables in front matter, but `permalink` is an exception. [Read more about Permalinks](/docs/permalinks/).
 * `layout`: Wrap current template with a layout template found in the `_includes` folder. [Read more about Layouts](/docs/layouts/).
 * `pagination`: Enable to iterate over data. Output multiple HTML files from a single template. [Read more about Pagination](/docs/pagination/).
 * `tags`: A single string or array that identifies that a piece of content is part of a collection. Collections can be reused in any other template. [Read more about Collections](/docs/collections/).

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -156,7 +156,7 @@ pagination:
 
 ## Remapping with permalinks
 
-Pagination variables also work here. Here’s an example of a permalink using the pagination page number:
+Normally, front matter does not support template syntax, but `permalink` does, enabling parametric URLs via pagination variables. Here’s an example of a permalink using the pagination page number:
 
 {% raw %}
 ```markdown


### PR DESCRIPTION
Attempt at clarifying documentation so that it is explicit that:

- front matter does not support template syntax
- permalink as a front matter key is the sole exception

see https://github.com/11ty/eleventy/issues/135#issuecomment-391937032
see https://github.com/11ty/eleventy/issues/315