### PR TITLE
use inline-block to maintain line-break on copy-paste scene

### DIFF
--- a/_includes/components/code.css
+++ b/_includes/components/code.css
@@ -59,7 +59,6 @@ pre + .note {
 
 .highlight-line {
   display: inline-block;
-  min-width: 100%;
 
   /* del, ins, mark default styles */
   text-decoration: none;
@@ -69,6 +68,10 @@ pre + .note {
 /* allow highlighting empty lines */
 .highlight-line:empty:before {
   content: " ";
+}
+
+.highlight-line:not(:last-child) {
+	min-width: 100%;
 }
 
 .highlight-line-isdir {

--- a/_includes/components/code.css
+++ b/_includes/components/code.css
@@ -58,7 +58,8 @@ pre + .note {
 
 
 .highlight-line {
-  display: block;
+  display: inline-block;
+  min-width: 100%;
 
   /* del, ins, mark default styles */
   text-decoration: none;
@@ -68,10 +69,6 @@ pre + .note {
 /* allow highlighting empty lines */
 .highlight-line:empty:before {
   content: " ";
-}
-/* avoid double line breaks when using display: block; */
-.highlight-line + br {
-  display: none;
 }
 
 .highlight-line-isdir {


### PR DESCRIPTION
by using `display: inline-block` and `min-width:100%` instead removing the whole line break, 
it will keeps the line break (while avoid the double line break issue, of course) so the pasted result doesn't wrapped into one line.