### PR TITLE
Add note on data file names

### DIFF
--- a/docs/data-template-dir.md
+++ b/docs/data-template-dir.md
@@ -27,6 +27,8 @@ For example, consider a template located at `posts/subdir/my-first-blog-post.md`
     * `posts/posts.json`
 1. [Global Data Files](/docs/data-global/) in `_data/*` (available to all templates)
 
+{% callout "info" %}Note that the name of the data file must match either the post or the directory it resides within.{% endcallout %}
+
 ### Change the `.11tydata.js` file suffix {% addedin "0.5.3" %}
 
 Use the [Configuration API to change the file suffix](/docs/config/#change-file-suffix-for-template-and-directory-data-files) used to search for Eleventy data files.


### PR DESCRIPTION
When I initially read the docs I thought that the names chosen for the data files were merely to illustrate where they lived. I didn't realize that the data files won't work unless they exactly match their corresponding post or directory names.