### PR TITLE
Remove npx as npm scripts don’t need it

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "build": "npx eleventy",
-    "build-production": "ELEVENTY_PRODUCTION=true npx eleventy"
+    "build": "eleventy",
+    "build-production": "ELEVENTY_PRODUCTION=true eleventy"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
AFAIK, you only need `npx` while manually running packages in CLI, npm scripts see all installed packages and able to run them without any help. Not sure if this PR makes too much sense, but why not.