### PR TITLE
Refer to scoped npm package for execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The website and documentation for the [Eleventy static site generator](https://g
 
 ```
 npm install
-npx eleventy --serve
+npx @11ty/eleventy --serve
 ```
 
 Browse to http://localhost:8080/ (8080 is the default but it’ll bump to a new port if that one is taken, so use whatever port shows up when you run the `--serve` command).


### PR DESCRIPTION
I'm not using `npx` (but install the runtime as devDependency, because my project depends on it).
Assuming it behaves similiar to those executables under `node_modules/.bin` it would be `eleventy`, yes.
But we want [`@11ty/eleventy`](https://www.npmjs.com/package/@11ty/eleventy), not [`eleventy`](https://www.npmjs.com/package/eleventy).