### PR TITLE
Add config to highlight frontmatter in markdown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -3,10 +3,15 @@ const htmlmin = require("html-minifier");
 const CleanCSS = require("clean-css");
 const HumanReadable = require('human-readable-numbers');
 const syntaxHighlightPlugin = require("@11ty/eleventy-plugin-syntaxhighlight");
+const loadLanguages = require('prismjs/components/');
+
 const rssPlugin = require("@11ty/eleventy-plugin-rss");
 const inclusiveLanguagePlugin = require("@11ty/eleventy-plugin-inclusive-language");
 const cfg = require("./_data/config.js");
 const avatarExceptions = require("./_data/avatarFileMap.json");
+
+// Load yaml from Prism to highlight frontmatter
+loadLanguages(['yaml']);
 
 const shortcodes = {
 	avatar: function(filename, linkUrl, text = "") {
@@ -36,7 +41,16 @@ module.exports = function(eleventyConfig) {
 	eleventyConfig.setDataDeepMerge(true);
 
 	eleventyConfig.addPlugin(syntaxHighlightPlugin, {
-		templateFormats: "md"
+    templateFormats: "md",
+    init: function({ Prism }) {
+      Prism.languages.markdown = Prism.languages.extend('markup', {
+        'frontmatter': {
+          pattern: /^---[\s\S]*?^---$/m,
+          greedy: true,
+          inside: Prism.languages.yaml
+        }
+      });
+    }
 	});
 	eleventyConfig.addPlugin(rssPlugin);
 	// eleventyConfig.addPlugin(inclusiveLanguagePlugin);
@@ -46,7 +60,7 @@ module.exports = function(eleventyConfig) {
 	});
 
 	eleventyConfig.addShortcode("emoji", function(emoji, alt = "") {
-		return `<span aria-hidden="true" class="emoji">${emoji}</span>` + 
+		return `<span aria-hidden="true" class="emoji">${emoji}</span>` +
 			(alt ? `<span class="sr-only">${alt}</span>` : "");
 	});
 


### PR DESCRIPTION
Frontmatter in markdown is currently broken in the current documentation and potentially confusing (it confused me!). 

Example of broken highlighting (from [pagination](https://11ty.io/docs/pagination/)):
<img width="894" alt="Screenshot 2019-04-22 at 21 58 55" src="https://user-images.githubusercontent.com/1131579/56524975-a151f900-654a-11e9-93ed-6b8a39e3f770.png">

`size` should be in the `pagination`-collection but appears outside.

This PR adds a rule to recognize frontmatter in markdown codeblocks by looking for the dash-fence (`---`) and loads the yaml rules from Prism inside it. 

<img width="889" alt="Screenshot 2019-04-22 at 21 58 08" src="https://user-images.githubusercontent.com/1131579/56525247-01e13600-654b-11e9-9a19-ffd765c7b6be.png">

I'm two days new to 11ty (hence my interest in its documentation), but I hope this is a decent approach. Review and proposal for changes are more than welcome – I'm here to learn!