### PR TITLE
Add eleventy-sanity-blog-boilerplate to starters

### DIFF
--- a/_data/starters.json
+++ b/_data/starters.json
@@ -40,5 +40,11 @@
 		"name": "Seven",
 		"description": "An eleventy template based on bootstrap4layouts. Includes webpack, sass version of bootstrap, vue.js powered search and a whole lot more.",
 		"author": "planetoftheweb"
+	},
+	{
+		"url": "https://github.com/kmelve/eleventy-sanity-blog-boilerplate",
+		"name": "eleventy-sanity-blog-boilerplate",
+		"description": "An eleventy + headless CMS blog boilerplate. Includes Sanity Studio, quick start, config and intstructions for deploying on Netlify and `now`.",
+		"author": "kmelve"
 	}
 ]


### PR DESCRIPTION
As per question on [twitter](https://twitter.com/hi_bz/status/1127277952478187521) I went ahead a made a starter for using 11ty with a headless CMS. The data-fetching/page-generation-part of it should be relatively easily adaptable for other API sources as well. It also demonstrates how to wrap 11ty in a monorepo.