### PR TITLE
fix(layouts): fix layout title by adding missing space character

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description" content="{% if subtitle %}{{ subtitle }} for Eleventy,{% else %}Eleventy is{% endif %} a simpler static site generator.">
-		<title>{{ subtitle + '-' if subtitle}} Eleventy</title>
+		<title>{{ subtitle + ' -' if subtitle}} Eleventy</title>
 {%- set css %}
 {% include 'components/font-titles.css' %}
 {{ googlefonts | safe }}

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<meta name="description" content="{% if subtitle %}{{ subtitle }} for Eleventy,{% else %}Eleventy is{% endif %} a simpler static site generator.">
-		<title>{{ subtitle + ' -' if subtitle}} Eleventy</title>
+		<title>{{ subtitle + '—' if subtitle}}Eleventy</title>
 {%- set css %}
 {% include 'components/font-titles.css' %}
 {{ googlefonts | safe }}


### PR DESCRIPTION
- Fix layout title by adding missing space character
  - Example output:
    - Before: `Overview- Eleventy`
    - After: `Overview - Eleventy`
