### PR TITLE
Proposal: change news order

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,15 +27,15 @@ Run `eleventy --serve` to start up a hot-reloading web server. Then open `http:/
 
 ## News
 
-* 2017 December 20—[Eleventy’s very first (and second and third) release](https://github.com/11ty/eleventy/releases?after=v0.1.3)
-* 2018 February—[Introducing Eleventy, a new Static Site Generator](https://www.zachleat.com/web/introducing-eleventy/)
-* 2018 March—[Eleventy wins Google Open Source Award](https://www.zachleat.com/web/eleventy-google-award/)
-* 2018 May 23—James Williamson delivers [Eleventy’s mascot](https://twitter.com/jameswillweb/status/999052022497316865), named [Edison the Static-Generating Possum](https://twitter.com/jameswillweb/status/1131956888332058624).
-* 2018 September—[Google’s {% avatar "v8js" %}V8 web site launches using Eleventy](https://twitter.com/v8js/status/1044202940494475265)
-* 2018 November—[Happy First Birthday, Eleventy! 🎉](https://www.zachleat.com/web/eleventy-birthday/)
-* 2018 December—[Turn Jekyll up to Eleventy—a lovely tutorial by {% avatar "paulrobertlloyd" %}Paul Robert Lloyd](https://24ways.org/2018/turn-jekyll-up-to-eleventy/)
-* 2019 March—[CERN 2019 WorldWideWeb Rebuild](https://twitter.com/eleven_ty/status/1106589569238085637) site rebuilt using Eleventy!
 * 2019 April 26—[Eleventy wins second Google Open Source Award](https://opensource.googleblog.com/2019/04/google-open-source-peer-bonus-winners.html)
+* 2019 March—[CERN 2019 WorldWideWeb Rebuild](https://twitter.com/eleven_ty/status/1106589569238085637) site rebuilt using Eleventy!
+* 2018 December—[Turn Jekyll up to Eleventy—a lovely tutorial by {% avatar "paulrobertlloyd" %}Paul Robert Lloyd](https://24ways.org/2018/turn-jekyll-up-to-eleventy/)
+* 2018 November—[Happy First Birthday, Eleventy! 🎉](https://www.zachleat.com/web/eleventy-birthday/)
+* 2018 September—[Google’s {% avatar "v8js" %}V8 web site launches using Eleventy](https://twitter.com/v8js/status/1044202940494475265)
+* 2018 May 23—James Williamson delivers [Eleventy’s mascot](https://twitter.com/jameswillweb/status/999052022497316865), named [Edison the Static-Generating Possum](https://twitter.com/jameswillweb/status/1131956888332058624).
+* 2018 March—[Eleventy wins Google Open Source Award](https://www.zachleat.com/web/eleventy-google-award/)
+* 2018 February—[Introducing Eleventy, a new Static Site Generator](https://www.zachleat.com/web/introducing-eleventy/)
+* 2017 December 20—[Eleventy’s very first (and second and third) release](https://github.com/11ty/eleventy/releases?after=v0.1.3)
 
 ## Used At
 


### PR DESCRIPTION
Change the news list to have the most recent at the top, so visitors to the site see it first. Reasons:
(1) First time I visited the page, I momentarily assumed nothing had happened on the project since 2017. Presume others may make the same error.
(2) For new or returning visitors, news from a year or two ago isn't as relevant as the most recent announcements, so offer the newest first.