### PR TITLE
make Passthrough File Copy label more descriptive

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -1,5 +1,5 @@
 ---
-subtitle: Passthrough Copy
+subtitle: Passthrough File Copy
 tags:
   - docs-config
 ---


### PR DESCRIPTION
I just ran in circles for about an hour trying to find the Passthrough File Copy settings (I didn't know what they were called or what to search for - I just wanted to drop in raw, static CSS and JS for use with my site). I kept on skipping over this section in the navbar because I thought it referred to "copy" in the marketing sense. The full header is much clearer to me, and I wish it had been in the nav. Thanks for everything you do and for considering this change!