### PR TITLE
Tiny fix on tag pages documentation

### DIFF
--- a/docs/quicktips/tag-pages.md
+++ b/docs/quicktips/tag-pages.md
@@ -28,7 +28,7 @@ permalink: /tags/{{ tag }}/
 <ol>
 {% set taglist = collections[ tag ] %}
 {% for post in taglist | reverse %}
-  <li><a href="{{ post.url | url }}">{{ post.data.title }}</li>
+  <li><a href="{{ post.url | url }}">{{ post.data.title }}</a></li>
 {% endfor %}
 </ol>
 ```


### PR DESCRIPTION
In the code sample the anchor tag is not closed.  DOM seems to parse something like this:

```html
<li><a> 
       <li><a>
              <li><a>
```