### PR TITLE
sort templates page content

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -12,6 +12,6 @@ tags: docs
 ---
 # {{ subtitle }}
 
-{% for section in collections["docs-templates"] -%}
+{% for section in collections["docs-templates"] | sortMenu(submenuSortOrder) -%}
 * [{{ section.data.subtitle }}]({{ section.data.page.url }}){% if section.data.excerpt %}: {{ section.data.excerpt }}{% endif %}
 {% endfor %}


### PR DESCRIPTION
I think if [templates](https://www.11ty.io/docs/templates/) page's content item sort order equal sub menu sort order, it more helpful to reader.