### PR TITLE
Fix external link in debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -11,7 +11,7 @@ Having trouble? Want to see what Eleventy is doing behind the scenes? Use `DEBUG
 DEBUG=Eleventy* eleventy
 ```
 
-It’s [different if you’re on Windows](https://www.npmjs.com/package/debug#windows-note).
+It’s [different if you’re on Windows](https://www.npmjs.com/package/debug#windows-command-prompt-notes).
 
 This will tell you exactly what directories Eleventy is using for data, includes, input, and output. It’ll tell you what search globs it uses to find your templates and what templates it finds. If you’re having trouble, enable this.
 


### PR DESCRIPTION
External link to the `debug` npm package docs used outdated `id` value for in-page link. This PR updates link to use correct `id` value.

Last line was somehow changed by GitHub's web editor. 🤷🏻‍♂️