### PR TITLE
Add website (UCLA Undergraduate Students Association)

### DIFF
--- a/_data/sites/usac.json
+++ b/_data/sites/usac.json
@@ -1,0 +1,6 @@
+{
+	"url": "https://usac.ucla.edu/",
+	"name": "UCLA Undergraduate Students Association",
+	"description": "Official website of the Undergraduate Students Association, whose membership is comprised of every undergraduate student at UCLA (University of California, Los Angeles)",
+	"twitter": "uclaUSAC"
+}


### PR DESCRIPTION
I'm the webmaster for the student government at UCLA, and recently rebuilt our official website using Eleventy. Thank you for this amazing project!