### PR TITLE
Call out Browsersync `<body>` requirement on Getting Started page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -123,7 +123,9 @@ Watching…
 
 </div>
 
-Go to `http://localhost:8080/` or `http://localhost:8080/README/` to see your Eleventy site live! Make a change to your template files and save them—Eleventy using BrowserSync will refresh the browser with your new changes automatically.
+Go to `http://localhost:8080/` or `http://localhost:8080/README/` to see your Eleventy site live! Make a change to your template files and save them—Eleventy using BrowserSync will refresh the browser with your new changes automatically. 
+
+{% callout "info" %}<strong>Important Note</strong>: Editing README.md won't refresh your browser automatically, because <a href="https://browsersync.io/docs/#requirements">Browsersync requires a <code>&lt;body&gt;</code> tag in your template</a> for live-reload to work properly.{% endcallout %}
 
 Congratulations—you made something with Eleventy! Now put it to work with templating syntax, front matter, and data files.
 


### PR DESCRIPTION
This page currently says, 

> Make a change to your template files and save them—Eleventy using BrowserSync will refresh the browser with your new changes automatically.

It turns out that this isn't true for one of the two template files we just created in step 2, because README.md doesn't produce a `<body>` tag that Browsersync requires to make live-reload work. 

That caveat should be explained here in context, not just on the subsequent page of the docs, so people don't waste time like I did troubleshooting why edits to README.md aren't live-reloaded.