### PR TITLE
Note about global data filename case requirements

### DIFF
--- a/docs/data-global.md
+++ b/docs/data-global.md
@@ -31,6 +31,8 @@ This data will be available to your templates under the `userList` key like this
 }
 ```
 
+(Note: `kebab-case` is not supported in global data filenames.)
+
 ### Folders
 
 If a data file is in a folder, the folder name will inform your global data object structure. For example, in our previous example, consider if our `userList.json` file was moved into a `users` folder at `_data/users/userList.json`.


### PR DESCRIPTION
I tried using kebab case in my file names, but they didn't seem to be accessible in templates. (E.g. `image-host.json` wasn't accessing from `{{ image-host.base_url }}` or `{{ imageHost.base_url }}`, so I had to switch the filename to camel case, which worked fine.