### PR TITLE
Add "codewithprompt" shortcode (RFC)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -82,6 +82,16 @@ module.exports = function(eleventyConfig) {
 		return `<a href="${href}" class="minilink minilink-lower">${text}</a>`;
 	});
 
+	eleventyConfig.addPairedShortcode("codewithprompt", function(text, prePrefixCode, when) {
+		return `<div data-preprefix-${prePrefixCode}="${when}">
+
+\`\`\`bash
+${text.trim()}
+\`\`\`
+
+</div>`;
+	});
+
 	eleventyConfig.addShortcode("addedin", function(version, tag, extraClass) {
 		if( typeof version !== "string" ) {
 			tag = version.tag;

--- a/docs/global-installation.md
+++ b/docs/global-installation.md
@@ -7,13 +7,9 @@ subtitle: Install Eleventy Globally
 
 _Don’t include `~ $` when you run these commands._
 
-<div data-preprefix-cmdhomedir="first">
-
-```bash
+{% codewithprompt "cmdhomedir", "first" %}
 npm install -g @11ty/eleventy
-```
-
-</div>
+{% endcodewithprompt %}
 
 The above adds an `eleventy` command that you can use in any directory.
 


### PR DESCRIPTION
I saw this as an opportunity to make the docs cleaner, but then I started to wonder if you preferred using plain HTML/Markdown for simplicity.

Soooo what do you think?  I'll be glad to update the rest of the code blocks in this file to match if you like.