### PR TITLE
Added hyperlink to check internal links as part of build process

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,6 +11,7 @@ const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
 const rssPlugin = require("@11ty/eleventy-plugin-rss");
 const inclusiveLanguagePlugin = require("@11ty/eleventy-plugin-inclusive-language");
 const cfg = require("./_data/config.js");
+const slugify = require('slugify');
 
 // Load yaml from Prism to highlight frontmatter
 loadLanguages(['yaml']);
@@ -238,7 +239,7 @@ module.exports = function(eleventyConfig) {
 	}
 
 	function markdownItSlugify(s) {
-		return encodeURIComponent(removeExtraText(s).trim().toLowerCase().replace(/\s+/g, '-'));
+		return slugify(removeExtraText(s), { lower: true, remove: /[:’'`,]/g });
 	}
 
 	eleventyConfig.setLibrary("md", markdownIt({

--- a/_data/config.js
+++ b/_data/config.js
@@ -2,7 +2,7 @@ module.exports = {
 	outdated: false,
 	prerelease: false,
 	minifyHtml: true,
-	githubEdit: "https://github.com/11ty/11ty.io/tree/master/",
+	githubEdit: "https://github.com/11ty/11ty.io/blob/master/",
 	now: new Date(),
 	localDev: false
 };

--- a/_data/sites/andy-bell.json
+++ b/_data/sites/andy-bell.json
@@ -1,6 +1,6 @@
 {
 	"name": "Andy Bell",
-	"url": "https://hankchizljaw.io/",
+	"url": "https://hankchizljaw.com/",
 	"description": "The personal web site of Andy Bell, a front-end developer and designer with No Divide",
 	"twitter": "hankchizljaw"
 }

--- a/_data/sites/bradley-taunt.json
+++ b/_data/sites/bradley-taunt.json
@@ -1,6 +1,6 @@
 {
 	"name": "Bradley Taunt",
-	"url": "https://bradleytaunt.com/",
+	"url": "https://uglyduck.ca/",
 	"description": "Front-end designer & developer",
 	"twitter": "bradtaunt",
 	"source_url": "https://github.com/bradleytaunt/eleventy-taunt"

--- a/_data/sites/chris-collins.json
+++ b/_data/sites/chris-collins.json
@@ -1,6 +1,6 @@
 {
     "name": "Chris Collins",
-    "url": "https://chriscollins.me/",
+    "url": "https://www.chriscollins.me/",
     "description": "The personal web site of Chris Collins, a web designer and developer from Scotland.",
     "source_url": "https://github.com/chrisssycollins/chriscollins.me",
     "twitter": "scottishstoater"

--- a/_data/sites/duncan-davidson.json
+++ b/_data/sites/duncan-davidson.json
@@ -1,7 +1,7 @@
 {
 	"name": "Duncan Davidson",
-	"url": "https://duncandavidson.com/",
+	"url": "https://duncan.dev/",
 	"description": "Software developer, startup advocate, speaker, book author, and photographer.",
 	"twitter": "duncan",
-	"source_url": "https://github.com/duncan/duncandavidson.com"
+	"source_url": "https://github.com/duncan/website"
 }

--- a/_data/sites/homan.json
+++ b/_data/sites/homan.json
@@ -1,5 +1,5 @@
 {
-	"url": "https://www.homan.io",
+	"url": "https://homan.io",
 	"name": "The Ramblings of Derek Homan",
   "description": "programmer, nerd, human",
 	"source_url": "https://github.com/dhoman/homan-io",  

--- a/_data/sites/johan-brook.json
+++ b/_data/sites/johan-brook.json
@@ -1,6 +1,6 @@
 {
 	"name": "Johan Brook",
-	"url": "https://www.johanbrook.com/",
+	"url": "https://johanbrook.com/",
 	"description": "The personal website of Johan, a Swedish designer & developer",
 	"source_url": "https://github.com/johanbrook/johanbrook.com",
 	"twitter": "johanbrook"

--- a/_data/sites/max-boeck.json
+++ b/_data/sites/max-boeck.json
@@ -1,6 +1,6 @@
 {
 	"name": "Max Böck",
-	"url": "https://mxb.at/",
+	"url": "https://mxb.dev/",
 	"description": "I’m Max Böck, a frontend web developer and designer based in Vienna, Austria.",
 	"twitter": "mxbck",
 	"source_url": "https://github.com/maxboeck/mxb"

--- a/_data/sites/mirisuzanne.json
+++ b/_data/sites/mirisuzanne.json
@@ -1,5 +1,5 @@
 {
-	"url": "https://miriamsuzanne.com/",
+	"url": "https://www.miriamsuzanne.com/",
 	"name": "Miriam Suzanne",
 	"description": "personal site for everything Miriam creates as an author, web developer, musician, and playwright…",
 	"twitter": "mirisuzanne"

--- a/_data/sites/pborenstein.json
+++ b/_data/sites/pborenstein.json
@@ -1,6 +1,6 @@
 {
 	"name": "pborenstein",
-	"url": "https://pborenstein.com/",
+	"url": "https://www.pborenstein.com/",
 	"description": "I’m Philip Borenstein. I write documentation for developers.",
 	"twitter": "pborenstein",
 	"source_url": "https://github.com/pborenstein/pborenstein.com"

--- a/_data/sites/ride.json
+++ b/_data/sites/ride.json
@@ -1,5 +1,5 @@
 {
 	"name": "Chuanqi Sun",
-	"url": "https://ride.netlify.com",
+	"url": "https://ride.netlify.com/latest",
   "description": "I built an information hub for a local mountain biking club, which won me lots of praises from bikers"
 }

--- a/_data/sites/roland-toth.json
+++ b/_data/sites/roland-toth.json
@@ -1,6 +1,6 @@
 {
 	"name": "Roland Toth",
-	"url": "https://rolandtoth.hu/portfolio/",
+	"url": "https://rolandtoth.hu/",
 	"description": "The portfolio site of Roland Toth",
 	"twitter": "tproli"
 }

--- a/_data/sites/ryzokuken.json
+++ b/_data/sites/ryzokuken.json
@@ -1,5 +1,5 @@
 {
-	"url": "https://ryzokuken.github.io/",
+	"url": "https://ryzokuken.js.org/",
 	"name": "Ujjwal “Ryzokuken” Sharma",
 	"description": "Core collaborator @nodejs, Prole @electronjs. International Speaker and JavaScript/C++ developer. Helping out with @v8js and @tc39. GSoC mentor and ex-student.",
 	"source_url": "https://github.com/ryzokuken/ryzokuken.github.io",

--- a/_data/sites/surma.json
+++ b/_data/sites/surma.json
@@ -2,7 +2,7 @@
 	"name": "Surma",
 	"url": "https://dassur.ma/",
 	"description": "Web Advocate @Google. Internetrovert 🏳️‍🌈 Craving simplicity, finding it nowhere.",
-	"source_url": "https://github.com/surma/surma.github.io",
+	"source_url": "https://github.com/surma/dassur.ma",
 	"twitter": "DasSurma",
 	"featured": true
 }

--- a/_data/testimonials.json
+++ b/_data/testimonials.json
@@ -74,7 +74,7 @@
 		"text": "It's clean, elegant, easy to use, and does just enough to be useful without getting in the way. Excellent work 😊",
 		"twitter": "WebInspectInc",
 		"name": "Timothy Miller",
-		"source": "https://twitter.com/TJacobDesign/status/1017594017402572811"
+		"source": "https://twitter.com/WebInspectInc/status/1017594017402572811"
 	},
 	{
 		"text": "Holy cow! Eleventy is so crazy simple to work with.",

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,7 +44,7 @@ This allows you further customization options using Eleventy’s provided helper
 * Add [Shortcodes](/docs/shortcodes/).
 * Add [Custom Tags](/docs/custom-tags/).
 * Add [JavaScript Functions](/docs/languages/javascript/#javascript-template-functions) {% addedin "0.7.0" %}
-* Add custom [Collections](/docs/collections/) and use [Advanced Collection Filtering and Sorting](/docs/collections/#advanced%3A-custom-filtering-and-sorting).
+* Add custom [Collections](/docs/collections/) and use [Advanced Collection Filtering and Sorting](/docs/collections/#advanced-custom-filtering-and-sorting).
 * Add some [Plugins](/docs/plugins/).
 
 ## Configuration Options
@@ -525,7 +525,7 @@ module.exports = function(eleventyConfig) {
 
 ### Customize Front Matter Parsing Options {% addedin "0.9.0" %}
 
-* Documented at [Front Matter Data](/docs/data-frontmatter/#advanced%3A-customize-front-matter-parsing).
+* Documented at [Front Matter Data](/docs/data-frontmatter/#advanced-customize-front-matter-parsing).
 
 
 <!--

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,7 +44,7 @@ This allows you further customization options using Eleventy’s provided helper
 * Add [Shortcodes](/docs/shortcodes/).
 * Add [Custom Tags](/docs/custom-tags/).
 * Add [JavaScript Functions](/docs/languages/javascript/#javascript-template-functions) {% addedin "0.7.0" %}
-* Add custom [Collections](/docs/collections/) and use [Advanced Collection Filtering and Sorting](/docs/collections/#advanced-custom-filtering-and-sorting).
+* Add custom [Collections](/docs/collections/) and use [Advanced Collection Filtering and Sorting](/docs/collections/#advanced%3A-custom-filtering-and-sorting).
 * Add some [Plugins](/docs/plugins/).
 
 ## Configuration Options

--- a/docs/data-frontmatter-customize.md
+++ b/docs/data-frontmatter-customize.md
@@ -79,7 +79,7 @@ Using `excerpt_alias: 'my_custom_excerpt'` means that the excerpt will be availa
 
 ### Example: using TOML for front matter parsing {% addedin "0.9.0" %}
 
-While Eleventy does include support for [JSON, YAML, and JS front matter out of the box](#alternative-front-matter-formats), you may want to add additional formats too.
+While Eleventy does include support for [JSON, YAML, and JS front matter out of the box](/docs/data-frontmatter/#alternative-front-matter-formats), you may want to add additional formats too.
 
 {% codetitle ".eleventy.js" %}
 

--- a/docs/data-frontmatter-customize.md
+++ b/docs/data-frontmatter-customize.md
@@ -60,7 +60,7 @@ This is a continuation of my content…
 
 #### Changing where your excerpt is stored
 
-If you don’t want to use `page.excerpt` to store your excerpt value, then use your own `excerpt_alias` option ([any valid path to Lodash Set will work](https://lodash.com/docs/4.17.11#set)) like so:
+If you don’t want to use `page.excerpt` to store your excerpt value, then use your own `excerpt_alias` option ([any valid path to Lodash Set will work](https://lodash.com/docs/4.17.15#set)) like so:
 
 {% codetitle ".eleventy.js" %}
 

--- a/docs/data-frontmatter.md
+++ b/docs/data-frontmatter.md
@@ -87,7 +87,7 @@ Note that Liquid templates do not allow executing a function in output `{% raw %
 
 ### Add your own format {% addedin "0.9.0" %}
 
-You can [customize Front Matter Parsing](/docs/data-frontmatter-customize/) in Eleventy to add your own custom format. We have an [example to do this with support for TOML](/docs/data-frontmatter-customize/#example%3A-using-toml-for-front-matter-parsing).
+You can [customize Front Matter Parsing](/docs/data-frontmatter-customize/) in Eleventy to add your own custom format. We have an [example to do this with support for TOML](/docs/data-frontmatter-customize/#example-using-toml-for-front-matter-parsing).
 
 ## Advanced: Customize Front Matter Parsing {% addedin "0.9.0" %}
 

--- a/docs/data-js.md
+++ b/docs/data-js.md
@@ -62,8 +62,8 @@ module.exports = async function() {
 
 ## Examples
 
-- [Example: Using GraphQL](#example%3A-using-graphql)
-- [Example: Exposing Environment Variables](#example%3A-exposing-environment-variables)
+- [Example: Using GraphQL](#example-using-graphql)
+- [Example: Exposing Environment Variables](#example-exposing-environment-variables)
 
 ### Example: Using GraphQL
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -70,7 +70,7 @@ The `fileSlug` variable is mapped from inputPath and is useful for creating your
 
 The `filePathStem` variable is mapped from inputPath and is useful if you’ve inherited a project that doesn’t use clean [permalinks](/docs/permalinks/).
 
-{% callout "info" %}<strong>Careful with this one</strong> and remember that <a href="/docs/permalinks/#cool-uris-don’t-change">Cool URI’s don’t change</a>.{% endcallout %}
+{% callout "info" %}<strong>Careful with this one</strong> and remember that <a href="/docs/permalinks/#cool-uris-dont-change">Cool URI’s don’t change</a>.{% endcallout %}
 
 If you absolutely need a file extension on your output, you might use it like this:
 

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -32,7 +32,7 @@ Valid `date` values:
 
 * `Last Modified`: automatically resolves to the file’s last modified date
 * `Created`: automatically resolves to the file’s created date (default, this is what is used when `date` is omitted).
-* `2016-01-01` or any other valid [YAML date value](http://yaml.org/type/timestamp.html) (leaving off the time assumes midnight in UTC, or `00:00:00Z`)
+* `2016-01-01` or any other valid [YAML date value](https://yaml.org/type/timestamp.html) (leaving off the time assumes midnight in UTC, or `00:00:00Z`)
 * `"2016-01-01"` or any other valid UTC **string** that [Luxon’s `DateTime.fromISO`](https://moment.github.io/luxon/docs/manual/parsing.html#parsing-technical-formats) can parse (see also the [Luxon API docs](https://moment.github.io/luxon/docs/class/src/datetime.js~DateTime.html#static-method-fromISO)).
 
 If a `date` key is omitted from the file, the date is assumed to be:

--- a/docs/languages/ejs.md
+++ b/docs/languages/ejs.md
@@ -15,7 +15,7 @@ You can override a `.ejs` file’s template engine. Read more at [Changing a Tem
 
 ### Optional: Compile/Render Options {% addedin "0.3.0" %}
 
-See “Options” on the [EJS home page](http://ejs.co/).
+See “Options” on the [EJS home page](https://ejs.co/).
 
 ```
 module.exports = function(eleventyConfig) {

--- a/docs/languages/handlebars.md
+++ b/docs/languages/handlebars.md
@@ -47,7 +47,7 @@ module.exports = function(eleventyConfig) {
 
 Helpers are used to transform or modify content. You can add Handlebars specific helpers, but you probably want to add a [Universal shortcode](/docs/filters/) instead.
 
-Read more about [Handlebars Helpers syntax](http://handlebarsjs.com/#helpers)
+Read more about [Handlebars Helpers syntax](https://handlebarsjs.com/#helpers)
 
 ```js
 module.exports = function(eleventyConfig) {

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -114,7 +114,7 @@ module.exports = function(eleventyConfig) {
 | ----------------- | ------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------ |
 | Nunjucks          | `{{ content | safe }}`                                | `{{ value }}`                     | [Docs](https://mozilla.github.io/nunjucks/templating.html#safe)                      |
 | EJS               | `<%- content %>`                                       | `<%= value %>`                    | [Docs](https://www.npmjs.com/package/ejs#tags)                                       |
-| Handlebars        | `{{{ content }}}` (triple stash)                       | `{{ value }}` (double stash)      | [Docs](http://handlebarsjs.com/#html-escaping)                                       |
+| Handlebars        | `{{{ content }}}` (triple stash)                       | `{{ value }}` (double stash)      | [Docs](https://handlebarsjs.com/#html-escaping)                                       |
 | Mustache          | `{{{ content }}}` (triple stash)                       | `{{ value }}` (double stash)      | [Docs](https://github.com/janl/mustache.js#variables)                                |
 | Liquid            | is by default unescaped so you can use `{{ content }}` | `{{ value | escape}}`            | [Docs](http://shopify.github.io/liquid/filters/escape/)                              |
 | HAML              | `! #{ content }`                                       | `= #{ content }`                  | [Docs](http://haml.info/docs/yardoc/file.REFERENCE.html#unescaping_html)             |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,7 +15,7 @@ Eleventy **works with multiple template languages**. You can pick one or use the
 
 {% templatelangs templatetypes, page %}
 
-Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#they%E2%80%99re-not-server-side-rendered%2C-they%E2%80%99re-pre-rendered" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
+Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#theyre-not-server-side-rendered-theyre-pre-rendered" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
 
 Eleventy is **incremental**. You don’t need to start an Eleventy project from scratch. Eleventy is flexible enough to allow conversion of only a few templates at a time. Migrate as fast or as slow as you’d like.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ There are a bunch of [sites built using Eleventy](/docs/sites/). But listen to w
 This project aims to directly compete with all other Static Site Generators. We encourage you to try out our competition:
 
 * [Jekyll](https://jekyllrb.com/) (Ruby)
-* [Hugo](http://gohugo.io/) (Go)
+* [Hugo](https://gohugo.io/) (Go)
 * [Hexo](https://hexo.io/) (JavaScript)
 * [Gatsby](https://www.gatsbyjs.org/) (JavaScript using React)
 * [Nuxt](https://www.staticgen.com/nuxt) (JavaScript using Vue)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,7 +15,7 @@ Eleventy **works with multiple template languages**. You can pick one or use the
 
 {% templatelangs templatetypes, page %}
 
-Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#pre-rendered-templates" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
+Eleventy is **not a JavaScript framework**—that means *zero boilerplate client-side JavaScript*. We’re thinking long term and opting out of the framework rat race. The tool chain, code conventions, and modules you use in your front end stack are decoupled from this tool. Work from a solid foundation of <a href="/docs/resources/#they%E2%80%99re-not-server-side-rendered%2C-they%E2%80%99re-pre-rendered" class="buzzword">pre-rendered templates</a> that suit your project’s <a href="/docs/resources/#progressive-enhancement" class="buzzword">progressive enhancement</a> baseline requirements.
 
 Eleventy is **incremental**. You don’t need to start an Eleventy project from scratch. Eleventy is flexible enough to allow conversion of only a few templates at a time. Migrate as fast or as slow as you’d like.
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -381,7 +381,7 @@ Paginates to:
 
 _(More discussion at [Issue #194](https://github.com/11ty/eleventy/issues/194))_
 
-As an aside, this could also be achieved in a more verbose way using the [Collection API](/docs/collections/#advanced%3A-custom-filtering-and-sorting). This could also be done using the new `before` callback {% addedin "0.10.0" %}.
+As an aside, this could also be achieved in a more verbose way using the [Collection API](/docs/collections/#advanced-custom-filtering-and-sorting). This could also be done using the new `before` callback {% addedin "0.10.0" %}.
 
 ### Blacklisting or Filtering Values {% addedin "0.4.0" %}
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -348,7 +348,7 @@ pagination:
 ```
 {% endraw %}
 
-The above generates a list of links but you could do a lot more. See what’s available in the [Collection documentation](/docs/collections/#individual-collection-items-(useful-for-sort-callbacks)) (specifically `templateContent`). If you’d like to use this to automatically generate Tag pages for your content, please read [Quick Tip #004—Create Tag Pages for your Blog](/docs/quicktips/tag-pages/).
+The above generates a list of links but you could do a lot more. See what’s available in the [Collection documentation](/docs/collections/) (specifically `templateContent`). If you’d like to use this to automatically generate Tag pages for your content, please read [Quick Tip #004—Create Tag Pages for your Blog](/docs/quicktips/tag-pages/).
 
 ## Modifying the Data Set prior to Pagination
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -526,9 +526,9 @@ Now `collections.myCollection` will have both output pages in the collection arr
 
 ## Full Pagination Option List
 
-* `data` (String) [Lodash.get path](https://lodash.com/docs/4.17.10#get) to point to the target data set.
+* `data` (String) [Lodash.get path](https://lodash.com/docs/4.17.15#get) to point to the target data set.
 * `size` (Number, required)
-* `alias` (String) [Lodash.set path](https://lodash.com/docs/4.17.10#set) to point to the property to set.
+* `alias` (String) [Lodash.set path](https://lodash.com/docs/4.17.15#set) to point to the property to set.
 * `resolve: values` {% addedin "0.4.0" %}
 * `filter` (Array) {% addedin "0.4.0" %}
 * `reverse: true` (Boolean) {% addedin "0.7.0" %}

--- a/docs/permalinks.md
+++ b/docs/permalinks.md
@@ -183,7 +183,7 @@ module.exports = function(eleventyConfig) {
 
 ### Use filters!
 
-Use the provided [`slug` filter](/docs/filters/#slug) to modify other data available in the template.
+Use the provided [`slug` filter](/docs/filters/slug/) to modify other data available in the template.
 
 {% codetitle "YAML Front Matter using Liquid, Nunjucks", "Syntax" %}
 

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -10,7 +10,7 @@ eleventyNavigation:
 * [I want to use the same Input and Output directory.](/docs/languages/html/#same-input-output)
 * [When I display a date, it’s off by one day.](/docs/dates/#dates-off-by-one-day)
 * [My markdown file has a bunch of extra `pre` and `code` blocks.](/docs/languages/markdown/#there-are-extra-and-in-my-output)
-* [Why can’t I return markdown from paired shortcodes to use in a markdown file?](/docs/languages/markdown/#why-can’t-i-return-markdown-from-paired-shortcodes-to-use-in-a-markdown-file)
+* [Why can’t I return markdown from paired shortcodes to use in a markdown file?](/docs/languages/markdown/#why-cant-i-return-markdown-from-paired-shortcodes-to-use-in-a-markdown-file)
 * [My collections are out of order because I’m using Array reverse() on the collections global](/docs/collections/#array-reverse)
 * [My collections are out of order when I deploy on a server.](/docs/dates/#collections-out-of-order-when-you-run-eleventy-on-your-server)
 * [I’m porting from Jekyll and I want to use Quoted Include Paths in my Liquid Templates.](/docs/languages/liquid/#quoted-include-paths)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -25,9 +25,9 @@ All official plugins live under the `@11ty` npm organization and plugin names wi
 * [eleventy-filter-npm-package-downloads](https://www.npmjs.com/package/eleventy-filter-npm-package-downloads) by [André Jaenisch](https://jaenis.ch/) will show you the number of downloads for the given npm package.
 * [eleventy-plugin-meta-generator](https://www.npmjs.com/package/eleventy-plugin-meta-generator) by [André Jaenisch](https://jaenis.ch/) will render a generator `<meta />` tag for you.
 * [eleventy-plugin-pwa](https://www.npmjs.com/package/eleventy-plugin-pwa) by [Nanda Okitavera](https://okitavera.me/) will generate a Service Worker for you.
-* [eleventy-plugin-reading-time](https://www.npmjs.com/package/eleventy-plugin-reading-time) by [Johan Brook](https://www.johanbrook.com/) will generate a tag for the estimated reading time.
+* [eleventy-plugin-reading-time](https://www.npmjs.com/package/eleventy-plugin-reading-time) by [Johan Brook](https://johanbrook.com/) will generate a tag for the estimated reading time.
 * [eleventy-plugin-respimg](https://www.npmjs.com/package/eleventy-plugin-respimg) by [Eric Portis](https://ericportis.com/) will take core of `srcset` attribute for responsive images for you.
-* [eleventy-plugin-typeset](https://www.npmjs.com/package/eleventy-plugin-typeset) by [Johan Brook](https://www.johanbrook.com/) will make your typography nicer.
+* [eleventy-plugin-typeset](https://www.npmjs.com/package/eleventy-plugin-typeset) by [Johan Brook](https://johanbrook.com/) will make your typography nicer.
 * [eleventy-plugin-yamldata](https://www.npmjs.com/package/eleventy-plugin-yamldata) by [Sungkwang Lee](https://gwangyi.github.io/) will allow you to use a yaml file as local data file.
 * [@shawnsandy/npm_info](https://www.npmjs.com/package/@shawnsandy/npm_info) by [Shawn Sandy](https://github.com/shawn-sandy) will provide you with package detail for an npm package or GitHub info.
 * [eleventy-plugin-lazyimages](https://www.npmjs.com/package/eleventy-plugin-lazyimages) by [Liam Fiddler](https://liamfiddler.com) will add progressive lazy loading to your images.
@@ -102,6 +102,6 @@ Plugin namespacing is an application feature and should not be used if you are c
 <div class="elv-community" id="community-resources">
   <h3 class="elv-community-hed">Community Resources</h3>
   <ul>
-    <li><a href="https://bryanlrobinson.com/blog/2019/06/21/creating-11ty-plugin-embed-svg-contents/">Creating an 11ty Plugin—SVG Embed Tool</a> by {% avatarlocalcache "twitter", "brob" %}Bryan Robinson</li>
+    <li><a href="https://bryanlrobinson.com/blog/creating-11ty-plugin-embed-svg-contents/">Creating an 11ty Plugin—SVG Embed Tool</a> by {% avatarlocalcache "twitter", "brob" %}Bryan Robinson</li>
   </ul>
 </div>

--- a/docs/quicktips/edit-on-github-links.md
+++ b/docs/quicktips/edit-on-github-links.md
@@ -31,7 +31,7 @@ Edit your your layout file to add the link. Provide the URL to the base of your 
     …
     <footer>
       © 2019 Eleventy
-      <a href="https://github.com/11ty/11ty.io/tree/master/{{ page.inputPath }}">Edit this page on GitHub</a>
+      <a href="https://github.com/11ty/11ty.io/blob/master/{{ page.inputPath }}">Edit this page on GitHub</a>
     </footer>
   </body>
 </html>

--- a/docs/quicktips/eliminate-js.md
+++ b/docs/quicktips/eliminate-js.md
@@ -6,7 +6,7 @@ date: 2019-01-31
 
 Older iterations of this website used a third party JavaScript widget to show the number of GitHub Stars the project currently had. You can see it in action on the [versioned docs for 0.7.1](https://v0-7-1.11ty.io/docs/) (scroll to the bottom).
 
-This was in fact the only `<script>` tag on the entire 11ty.io web site and it was from a third party. Naturally, it needed to be annihilated.
+This was in fact the only `<script>` tag on the entire [11ty.io](https://www.11ty.io/) web site and it was from a third party. Naturally, it needed to be annihilated.
 
 Let’s change up our architecture to ruthlessly eliminate this client-side JavaScript.
 

--- a/docs/quicktips/netlify-ifttt.md
+++ b/docs/quicktips/netlify-ifttt.md
@@ -7,7 +7,7 @@ In [Quick Tip #007](/docs/quicktips/eliminate-js/) we talked about migrating awa
 
 Updating this data at build time means that the data isn’t necessarily “live” (although the counts are likely cached at by at least one of the upstream dependencies of this widget, with a frequency that is out of your control).
 
-I’m comfortable with these numbers being a little delayed (more than the JS widget method was) and with this new approach I get more control over the frequency of updates BUT I do probably want to run the build at least once a day. To do this, I used an [IFTTT](https://ifttt.com/) applet to trigger my Netlify build to run every morning using [Netlify’s Build Hooks](https://www.netlify.com/docs/webhooks/#incoming-webhooks).
+I’m comfortable with these numbers being a little delayed (more than the JS widget method was) and with this new approach I get more control over the frequency of updates BUT I do probably want to run the build at least once a day. To do this, I used an [IFTTT](https://ifttt.com/) applet to trigger my Netlify build to run every morning using [Netlify’s Build Hooks](https://docs.netlify.com/configure-builds/build-hooks/).
 
 _Heavily inspired by [Phil Hawksworth’s work on RSS Jamstack](https://twitter.com/philhawksworth/status/1038067638369443840)._
 

--- a/docs/quicktips/not-found.md
+++ b/docs/quicktips/not-found.md
@@ -30,9 +30,9 @@ permalink: 404.html
 
 Eleventy will output this template to `404.html`.
 
-If you’re using [GitHub Pages](https://help.github.com/articles/creating-a-custom-404-page-for-your-github-pages-site/) or [Netlify](https://www.netlify.com/docs/redirects/#custom-404), there is no step two! A `404.html` file in your output directory is all you need.
+If you’re using [GitHub Pages](https://help.github.com/en/github/working-with-github-pages/creating-a-custom-404-page-for-your-github-pages-site) or [Netlify](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling), there is no step two! A `404.html` file in your output directory is all you need.
 
-Netlify even has lovely [multi-language 404 page support too using `Redirects`](https://www.netlify.com/docs/redirects/#custom-404).
+Netlify even has lovely [multi-language 404 page support too using `Redirects`](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling).
 
 ## .htaccess
 

--- a/docs/quicktipsfeed.njk
+++ b/docs/quicktipsfeed.njk
@@ -3,7 +3,7 @@ layout: false
 permalink: /docs/quicktips/feed.xml
 metadata:
   title: Eleventy Quick Tips
-  url: http://www.11ty.io/
+  url: https://www.11ty.io/
   author:
     name: Zach Leatherman
     email: zach@zachleat.com

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -32,7 +32,7 @@ Make components and markup data-driven so that you don’t have a bunch of one-o
 
 ## Serverless Friendly
 
-> “You can take your front-end skills and do things that typically only a back-end can do. You can write a JavaScript function that you run and receive a response from by hitting a URL.”—[The Power of Serverless](https://thepowerofserverless.info/) from [Chris Coyier](https://twitter.com/chriscoyier)
+> “You can take your front-end skills and do things that typically only a back-end can do. You can write a JavaScript function that you run and receive a response from by hitting a URL.”—[The Power of Serverless](https://serverless.css-tricks.com/) from [Chris Coyier](https://twitter.com/chriscoyier)
 
 Take care to make sure that <span class="buzzword">serverless</span> functions are <span class="buzzword">progressively enhanced</span>. That means they should either run at build time. If you call <span class="buzzword">serverless</span> functions in client-side JavaScript, they should be used for features that are outside the core functionality of the site.
 

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -41,8 +41,8 @@ _See all [Eleventy blog posts on zachleat.com](https://www.zachleat.com/web/elev
 * Sample Project: [Import your **Notist** events to an Eleventy site](https://eleventy-notist-example.netlify.com/) by {% avatarlocalcache "twitter", "philhawksworth" %}Phil Hawksworth
 * Sample Project: [Import your **Medium** posts to an Eleventy site](https://rss-jamstack.netlify.com/) by {% avatarlocalcache "twitter", "philhawksworth" %}Phil Hawksworth
 * [Import your **Disqus Comments** into Eleventy](https://github.com/11ty/eleventy-import-disqus/blob/master/README.md) by {% avatarlocalcache "twitter", "zachleat" %}Zach Leatherman
-* [Static Indieweb pt1: Syndicating Content](https://mxb.at/blog/syndicating-content-to-twitter-with-netlify-functions/) by {% avatarlocalcache "twitter", "mxbck" %}Max Böck
-* [Static Indieweb pt2: Using Webmentions](https://mxb.at/blog/using-webmentions-on-static-sites/) by {% avatarlocalcache "twitter", "mxbck" %}Max Böck
+* [Static Indieweb pt1: Syndicating Content](https://mxb.dev/blog/syndicating-content-to-twitter-with-netlify-functions/) by {% avatarlocalcache "twitter", "mxbck" %}Max Böck
+* [Static Indieweb pt2: Using Webmentions](https://mxb.dev/blog/using-webmentions-on-static-sites/) by {% avatarlocalcache "twitter", "mxbck" %}Max Böck
 * [Using Eleventy to Generate a Ghost Blog](https://david.darn.es/tutorial/2019/06/01/use-eleventy-to-generate-a-ghost-blog/) by {% avatarlocalcache "twitter", "DavidDarnes" %}David Darnes
 * [Consuming a headless CMS GraphQL API with Eleventy](https://www.webstoemp.com/blog/headless-cms-graphql-api-eleventy/) by {% avatarlocalcache "twitter", "jeromecoupe" %}Jérôme Coupé
 * [Import Tweets from Twitter API](https://www.d-hagemeier.com/en/articles/embed-twitter/) by {% avatarlocalcache "twitter", "DennisView" %}Dennis Hagemeier

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'unbound namespace prefix:' _site/*.html | tap-spot",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/  _site/*.html | tap-spot",
     "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
     "build": "eleventy",
     "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "fs-extra": "^8.1.0",
     "html-minifier": "^3.5.21",
     "human-readable-numbers": "^0.9.5",
-    "hyperlink": "^4.4.2",
+    "hyperlink": "^4.4.3",
     "lodash.defer": "^4.1.0",
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-table-of-contents": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'Unknown error' _site/*.html | tap-spot",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'Unknown error' --todo 'unbound namespace prefix:' _site/*.html | tap-spot",
     "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
     "build": "eleventy",
     "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'Unknown error' --todo 'unbound namespace prefix:' _site/*.html | tap-spot",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'unbound namespace prefix:' _site/*.html | tap-spot",
     "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
     "build": "eleventy",
     "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",
@@ -35,7 +35,7 @@
     "fs-extra": "^8.1.0",
     "html-minifier": "^3.5.21",
     "human-readable-numbers": "^0.9.5",
-    "hyperlink": "^4.4.1",
+    "hyperlink": "^4.4.2",
     "lodash.defer": "^4.1.0",
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-table-of-contents": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --todo 'Unknown error' _site/*.html | tap-spot",
     "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
     "build": "eleventy",
     "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
-    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/  _site/*.html | tap-spot",
-    "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ --skip '/.netlify/functions' _site/*.html | tap-spot",
+    "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ --skip '/.netlify/functions' _site/*.html | tap-spot",
     "build": "eleventy",
     "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",
     "postbuild-production": "npm run links-internal"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,11 @@
   "main": "_site/index.html",
   "scripts": {
     "assets": "cp node_modules/@11ty/logo/logo.png .",
+    "links-external": "hyperlink -r --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
+    "links-internal": "hyperlink -ri --root _site --canonicalroot https://11ty.io/ _site/*.html | tap-spot",
     "build": "eleventy",
-    "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy"
+    "build-production": "node node-avatars.js && ELEVENTY_PRODUCTION=true eleventy",
+    "postbuild-production": "npm run links-internal"
   },
   "repository": {
     "type": "git",
@@ -32,12 +35,14 @@
     "fs-extra": "^8.1.0",
     "html-minifier": "^3.5.21",
     "human-readable-numbers": "^0.9.5",
+    "hyperlink": "^4.4.1",
     "lodash.defer": "^4.1.0",
     "markdown-it-anchor": "^5.0.2",
     "markdown-it-table-of-contents": "^0.4.4",
     "node-fetch": "^2.3.0",
     "slugify": "^1.3.4",
     "sorted-object": "^2.0.1",
+    "tap-spot": "^1.1.1",
     "terser": "^4.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
The first commit adds hyperlink to the build process, which will highlight all current errors. Subsequent commits will try to fix the errors

Bugs:
- [x] `toc` generation in pagination generates wrong fragment link. Probably needs alignment of slugification between the markdown generator and the `toc` generator. Example: The `The before Callback`-link

## Broken external links

I think these require a thorough look:

```
  ✖ FAIL fragment-check _site/docs/sites/index.html --> https://glitch.com/edit/#!/cassey-til?path=README.md:1:0
  | operator: fragment-check
  | expected: id="!/cassey-til?path=README.md:1:0"
  |       at: _site/docs/sites/index.html:1851:460 <a href="https://glitch.com/edit/#!/cassey-til?path=README.md:1:0">...</a>

  ✖ FAIL fragment-check _site/docs/starter/index.html --> https://glitch.com/edit/#!/cassey-til?path=README.md:1:0
  | operator: fragment-check
  | expected: id="!/cassey-til?path=README.md:1:0"
  |       at: _site/docs/starter/index.html:1861:20 <a href="https://glitch.com/edit/#!/cassey-til?path=README.md:1:0" class="minilink">...</a>

  ✖ FAIL fragment-check _site/docs/custom-tags/index.html --> https://github.com/harttle/liquidjs#register-tags
  | operator: fragment-check
  | expected: id="register-tags"
  |       at: _site/docs/custom-tags/index.html:1813:14 <a href="https://github.com/harttle/liquidjs#register-tags">...</a>

  ✖ FAIL fragment-check _site/docs/languages/liquid/index.html --> https://github.com/harttle/liquidjs#options
  | operator: fragment-check
  | expected: id="options"
  |       at: _site/docs/languages/liquid/index.html:1832:247 <a href="https://github.com/harttle/liquidjs#options">...</a>

  ✖ FAIL fragment-check _site/docs/languages/liquid/index.html --> https://github.com/harttle/liquidjs#options
  | operator: fragment-check
  | expected: id="options"
  |       at: _site/docs/languages/liquid/index.html:1832:247 <a href="https://github.com/harttle/liquidjs#options">...</a>

  ✖ FAIL fragment-check _site/docs/languages/liquid/index.html --> https://github.com/harttle/liquidjs#register-filters
  | operator: fragment-check
  | expected: id="register-filters"
  |       at: _site/docs/languages/liquid/index.html:1900:29 <a href="https://github.com/harttle/liquidjs#register-filters">...</a>

  ✖ FAIL external-check https://devreldiaries.commons.host/
  | operator: external-check
  | expected: 200 https://devreldiaries.commons.host/
  |   actual: UNABLE_TO_VERIFY_LEAF_SIGNATURE
  |       at: _site/index.html:1782:25370 <a href="https://devreldiaries.commons.host/" class="elv-externalexempt">...</a>

  ✖ FAIL external-check https://mannahfoundation.org/
  | operator: external-check
  | expected: 200 https://mannahfoundation.org/
  |   actual: CERT_HAS_EXPIRED
  |       at: _site/index.html:1782:30070 <a href="https://mannahfoundation.org/" class="elv-externalexempt">...</a>

  ✖ FAIL external-check https://daffodilpedagogy.com/
  | operator: external-check
  | expected: 200 https://daffodilpedagogy.com/
  |   actual: DNS missing: daffodilpedagogy.com
  |       at: _site/docs/sites/index.html:1876:14 <a href="https://daffodilpedagogy.com/">...</a>

  ✖ FAIL external-check https://soldierpackers.com/
  | operator: external-check
  | expected: 200 https://soldierpackers.com/
  |   actual: DNS missing: soldierpackers.com
  |       at: _site/docs/sites/index.html:1918:14 <a href="https://soldierpackers.com/">...</a>
```

The remaining external broken links seem to be caused by hyperlink bugs I need to investigate