### PR TITLE
Fix Liquid sort descending code

### DIFF
--- a/docs/collections.md
+++ b/docs/collections.md
@@ -195,7 +195,8 @@ To sort descending in your template, you can use a filter to reverse the sort or
 {% raw %}
 ```
 <ul>
-{%- for post in collections.post | reverse -%}
+{% assign posts = collections.post | reverse %}
+{%- for post in posts -%}
   <li>{{ post.data.title }}</li>
 {%- endfor -%}
 </ul>


### PR DESCRIPTION
The old code was throwing errors:

```
Problem writing Eleventy templates: (more in DEBUG output)
> Having trouble rendering liquid (and markdown) template ./content/blog/index.md

`TemplateContentRenderError` was thrown
> Having trouble compiling template ./content/blog/index.md

`TemplateContentCompileError` was thrown
> illegal tag: {%- for post in collections.post | reverse -%}, file:./content/blog/index.md, line:3

`ParseError` was thrown
> illegal tag: {%- for post in collections.post | reverse -%}

`AssertionError` was thrown:
    AssertionError: illegal tag: {%- for post in collections.post | reverse -%}
        at assert 
...
```